### PR TITLE
fix undo package method

### DIFF
--- a/db/oci8/Migration.php
+++ b/db/oci8/Migration.php
@@ -140,7 +140,7 @@ class Migration extends \yii\db\Migration
         $backupPackageSql = $backupPackage['backup'];
 
         // check body exists
-        $packageComponents = preg_split('/CREATE\s+OR\s+REPLACE\s+PACKAGE\s+BODY/', $backupPackageSql);
+        $packageComponents = preg_split('/CREATE\s+OR\s+REPLACE\s+(?:EDITIONABLE\s+)?PACKAGE\s+BODY/', $backupPackageSql);
 
         $this->execute(trim($packageComponents[0]));
 


### PR DESCRIPTION
DBMS_METADATA.GET_DDL returns object's DDL with "EDITIONABLE" keyword in Oracle 12+.

http://www.igormelnikov.com/2013/11/oracle-database-12c-r1-edition-base.html